### PR TITLE
chore: sync dependabot config from template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,30 +1,47 @@
 version: 2
+
+# Canonical dependabot config for npm/TypeScript repos in forgesworn.
+# Synced from forgesworn/.github/templates/dependabot/dependabot.npm.yml.
+# Edit the template, not individual repos -- run the propagator to sync.
+#
+# Tiering:
+#   patch + minor  -> grouped, auto-merged on green CI
+#   major          -> individual PR, manual review
+#   TS / Node / framework majors -> ignored here, upgraded deliberately
+
 updates:
-  # npm dependencies — signet has runtime dependencies,
-  # so production bumps matter. Keep production and development
-  # groups separate so a runtime-dep bump doesn't hide inside
-  # a batch of devDep noise.
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 5
-    groups:
-      production-dependencies:
-        dependency-type: production
-      dev-dependencies:
-        dependency-type: development
+    open-pull-requests-limit: 10
     commit-message:
       prefix: chore
       include: scope
-  # GitHub Actions references in .github/workflows. Monthly is
-  # frequent enough; a weekly cadence would produce mostly trivial
-  # SHA bumps.
+    groups:
+      production-minor:
+        dependency-type: production
+        update-types: ["patch", "minor"]
+      dev-minor:
+        dependency-type: development
+        update-types: ["patch", "minor"]
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: monthly
+    open-pull-requests-limit: 5
     commit-message:
       prefix: chore
       include: scope
+    groups:
+      actions-minor:
+        update-types: ["patch", "minor"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+
+# Auto-merges dependabot PRs for patch/minor bumps once required checks pass.
+# Majors are never auto-merged -- they open a normal PR for deliberate review.
+# Security advisories always open their own PR and follow the same gate.
+#
+# Synced from forgesworn/.github/templates/dependabot/dependabot-auto-merge.yml.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
+
+      - name: Enable auto-merge for patch/minor
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"


### PR DESCRIPTION
Syncs canonical `dependabot.yml` and auto-merge workflow from `forgesworn/.github/templates/dependabot/`.

Changes:
- Patch/minor bumps grouped and auto-merged on green CI
- Majors open individual PRs (no more breaking changes hidden in group bumps)
- TypeScript, `@types/node`, and Node runtime majors ignored by dependabot -- upgraded deliberately