### PR TITLE
feat: re-export raw derive() for raw-purpose identities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -386,7 +386,11 @@ export {
 export type { SignetIdentity } from './identity-tree.js';
 
 // nsec-tree re-exports
-export { zeroise } from 'nsec-tree';
+// `derive` is the raw child-derivation primitive (root, purpose, index). Use it
+// to reproduce identities created under a RAW purpose — e.g. the nsec-tree CLI's
+// `derive path <name>` or a bunker's raw derivation — which live in a different
+// namespace from signet's `nostr:persona:<name>` personas (PROTOCOL v1.1 §3.1).
+export { derive, zeroise } from 'nsec-tree';
 export type { TreeRoot, Identity, Persona, LinkageProof } from 'nsec-tree';
 
 // NIP-19 encoding (nsec-tree/encoding)

--- a/tests/identity-tree.test.ts
+++ b/tests/identity-tree.test.ts
@@ -11,6 +11,7 @@ import {
   verifyLinkageProof,
   destroyIdentity,
 } from '../src/identity-tree.js'
+import { derive } from '../src/index.js'
 
 const TEST_MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
 
@@ -203,5 +204,26 @@ describe('Shamir backup round-trip', () => {
     expect(recovered.root.masterPubkey).toBe(original.root.masterPubkey)
     original.root.destroy()
     recovered.root.destroy()
+  })
+})
+
+describe('raw derive() re-export', () => {
+  it('reproduces a raw-purpose identity, distinct from the persona namespace', () => {
+    const identity = createSignetIdentity(TEST_MNEMONIC)
+
+    // A persona named X is purpose nostr:persona:X (PROTOCOL v1.1 §3.1).
+    const persona = deriveAdditionalPersona(identity.root, 'social')
+    const viaRawPersonaPurpose = derive(identity.root, 'nostr:persona:social', 0)
+    expect(viaRawPersonaPurpose.npub).toBe(persona.identity.npub)
+    expect(viaRawPersonaPurpose.npub).toBe(
+      'npub1qdztfxg9z46k8qg4707n747y9rt7kl3f954lju2pneesmc3ypf2q83gm0e',
+    )
+
+    // The RAW purpose "social" is a different identity (e.g. an nsec-tree CLI
+    // `derive path social`) — the re-export lets signet reproduce it too.
+    const raw = derive(identity.root, 'social', 0)
+    expect(raw.npub).not.toBe(persona.identity.npub)
+
+    destroyIdentity(identity)
   })
 })


### PR DESCRIPTION
## What

Re-export nsec-tree's raw `derive(root, purpose, index)` from signet.

## Why

Completes the persona-namespace reconciliation (forgesworn/nsec-tree#23). signet's personas live at `nostr:persona:<name>`, but raw-purpose identities — an nsec-tree CLI `derive path <name>`, or a bunker's raw derivation — are a separate namespace. This lets signet **reproduce and manage those raw identities too**, instead of only the `nostr:persona:` half.

## Tests

`npm test` — 747 pass (incl. new test: raw `nostr:persona:social` matches the persona and the frozen Vector 6 npub, while raw `social` differs). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)